### PR TITLE
Update TraefikEE to v2.6.0

### DIFF
--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: traefikee
-version: 0.1.11
-appVersion: "2.5.8"
+version: 0.2.0
+appVersion: "2.6.0"
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)
 kubeVersion: ">= 1.14.0-0"

--- a/traefikee/tests/proxy_test.yaml
+++ b/traefikee/tests/proxy_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: default-proxy
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "traefik/traefikee:v2.5.8"
+          value: "traefik/traefikee:v2.6.0"
   - it: should override defaults
     set:
       cluster: "mysupertraefikee"


### PR DESCRIPTION
### Motivation

Updates the TraefikEE image version to `v2.6.0`