### PR TITLE
Allow passing environment variables for controller and regular proxies

### DIFF
--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefikee
-version: 1.2.4
+version: 1.2.5
 appVersion: "2.8.3"
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)

--- a/traefikee/templates/proxy/deployment.yaml
+++ b/traefikee/templates/proxy/deployment.yaml
@@ -79,6 +79,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- range $key, $value := .Values.proxy.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+          {{- end }}
           securityContext:
             readOnlyRootFilesystem: true
             capabilities:

--- a/traefikee/templates/stateful-sets.yaml
+++ b/traefikee/templates/stateful-sets.yaml
@@ -251,6 +251,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.cluster }}-registry-token
                   key: token
+          {{- range $key, $value := .Values.controller.env }}
+            - name: {{ $key }}
+              value: {{ $value }}
+          {{- end }}
           securityContext:
             readOnlyRootFilesystem: true
             capabilities:

--- a/traefikee/values.yaml
+++ b/traefikee/values.yaml
@@ -47,6 +47,8 @@ controller:
 #    foo: bar
 #  additionalArguments:
 #    - --foo=bar
+#  env:
+#    foo: bar
 
 proxy:
   replicas: 2
@@ -75,6 +77,8 @@ proxy:
 #    foo: bar
 #  additionalArguments:
 #    - --foo=bar
+#  env:
+#    foo: bar
 
 mesh:
   enabled: false


### PR DESCRIPTION
### Description

Fixes: #42 

### Testing

Run something like:

```shell
helm template ./traefikee/ --set 'controller.env.foo=bar'
```

and look out for the 'env' section of the controller stateful set in the output. It should contain "foo=bar" at the end.

For lazy people:

```shell
helm template ./traefikee/ --set 'controller.env.foo=bar' | grep env: -A 20 | tail -n 21
```