### PR TITLE
Plugin registry token management improvement

### DIFF
--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -1,11 +1,7 @@
 apiVersion: v2
 name: traefikee
-version: 1.7.0
-<<<<<<< HEAD
+version: 1.8.0
 appVersion: v2.9.1
-=======
-appVersion: v2.9.0
->>>>>>> 65dd656 (manage registry token secret creation when manually set, remove checksum annotation in statefulset when token is set by hand)
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)
 kubeVersion: ">= 1.14.0-0"

--- a/traefikee/templates/stateful-sets.yaml
+++ b/traefikee/templates/stateful-sets.yaml
@@ -1,4 +1,5 @@
 {{- $tokenStr := include "traefikee-helm-chart.registry-token" . }}
+{{- if or (empty (.Values.registry).manualTokenSecret) (eq (.Values.registry).manualTokenSecret false) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -14,7 +15,7 @@ data:
 {{- else }}
   token: {{ .Values.registry.tokenSecret }}
 {{- end }}
-
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -40,15 +41,28 @@ spec:
       component: registry
   template:
     metadata:
-    {{- if empty (.Values.registry).tokenSecret }}
       annotations:
-        # This ensures that the registry pods will be rollout,
-        # if the token for the plugin registry has changed since last deployment.
+      # This ensures that the registry pods will be rollout,
+      # if the token for the plugin registry has changed since last deployment.
+      {{- if and (empty (.Values.registry).tokenSecret) (or (empty (.Values.registry).manualTokenSecret) (eq (.Values.registry).manualTokenSecret false)) }}
         checksum/config: {{ $tokenStr | sha256sum }}
-        {{- with (.Values.registry).podAnnotations }}
+      {{ else if eq (.Values.registry).manualTokenSecret true }}
+        {{- $tokenSecret := (lookup "v1" "Secret" .Release.Namespace (print .Values.cluster "-registry-token")) | default dict }}
+        {{- $tokenSecretData := (get $tokenSecret "data") | default dict }}
+        {{- $token := (get $tokenSecretData "token") | default dict }}
+        checksum/config: {{ $token | sha256sum }}
+      {{ else }}
+         checksum/config: {{ .Values.registry.tokenSecret | sha256sum }}
+      {{- end }}  
+        {{- with .Values.controller.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-    {{- end }}
+      labels:
+        component: controllers
+        {{ include "common.labels" . | nindent 8 }}
+        {{- with .Values.controller.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:        
         component: registry
         {{ include "common.labels" . | nindent 8 }}
@@ -190,15 +204,22 @@ spec:
   replicas: {{ .Values.controller.replicas }}
   template:
     metadata:
-    {{- if empty (.Values.registry).tokenSecret }}
       annotations:
-        # This ensures that the controller pods will be rollout,
-        # if the token for the plugin registry has changed since last deployment.
+      # This ensures that the controller pods will be rollout,
+      # if the token for the plugin registry has changed since last deployment.
+      {{- if and (empty (.Values.registry).tokenSecret) (or (empty (.Values.registry).manualTokenSecret) (eq (.Values.registry).manualTokenSecret false)) }}
         checksum/config: {{ $tokenStr | sha256sum }}
+      {{ else if eq (.Values.registry).manualTokenSecret true }}
+        {{- $tokenSecret := (lookup "v1" "Secret" .Release.Namespace (print .Values.cluster "-registry-token")) | default dict }}
+        {{- $tokenSecretData := (get $tokenSecret "data") | default dict }}
+        {{- $token := (get $tokenSecretData "token") | default dict }}
+        checksum/config: {{ $token | sha256sum }}
+      {{ else }}
+         checksum/config: {{ .Values.registry.tokenSecret | sha256sum }}
+      {{- end }} 
         {{- with .Values.controller.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-    {{- end }}
       labels:
         component: controllers
         {{ include "common.labels" . | nindent 8 }}

--- a/traefikee/values.yaml
+++ b/traefikee/values.yaml
@@ -31,6 +31,7 @@ image:
 #     foo: bar
 #   podAnnotations:
 #     foo: bar
+#   manualTokenSecret: true
 #   tokenSecret: "NJ00yx60K+Wm1yufuBM6fLq3fVKcv44RvBsVGiH40+U="
 
 controller:


### PR DESCRIPTION
This PR answer issue [#53](https://github.com/traefik/traefikee-helm-chart/issues/53) 

You can now pass the registry token as a value, and stateful set token checksum annotation will not be added.

Tested with and without token with this simple value: 
```yaml
cluster: "testdemapi"

image:
  name: traefik/traefikee
  tag: ""
  pullPolicy: IfNotPresent

controller:
  replicas: 1
  staticConfig:
    configMap:
      name: testdemapi-static-config
      key: static.yaml

proxy:
  replicas: 2
  serviceType: LoadBalancer
  ports:
    - name: http
      port: 80
    - name: https
      port: 443

registry:
  tokenSecret: "NJ00yx60K+Wm1yufuBM6fLq3fVKcv44RvBsVGiH40+U="

mesh:
  enabled: false
  kubedns: false
  clusterDomain: "traefikee.mesh"
```