### PR TITLE
Add terminationGracePeriodSeconds to the values

### DIFF
--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefikee
-version: 1.6.1
+version: 1.7.0
 appVersion: v2.9.1
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)

--- a/traefikee/templates/proxy/deployment.yaml
+++ b/traefikee/templates/proxy/deployment.yaml
@@ -57,7 +57,7 @@ spec:
                       values:
                         - proxies
                 topologyKey: "kubernetes.io/hostname"
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: {{ .Values.proxy.terminationGracePeriodSeconds | default 30 }}
       automountServiceAccountToken: false
       initContainers:
         - name: wait-dns

--- a/traefikee/values.yaml
+++ b/traefikee/values.yaml
@@ -101,6 +101,7 @@ proxy:
 #  podDisruptionBudget:
 #    minAvailable: 1
 #    maxUnavailable: 1
+# terminationGracePeriodSeconds: 30
 
 mesh:
   enabled: false


### PR DESCRIPTION
Hello,

As requested by Terminus in ticket [2968](https://traefik.zendesk.com/agent/tickets/2968), I've changed the way terminationGracePeriodSeconds is set in the proxy deployment helm chart.

Here, the value can be set through the value file, and if not set it will use the default value set in the previous version of the helm chart.

David