### PR TITLE
feat: allows to unset `spec.replicas` on proxy

### DIFF
--- a/traefikee/templates/proxy/deployment.yaml
+++ b/traefikee/templates/proxy/deployment.yaml
@@ -14,7 +14,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  replicas: {{ .Values.proxy.replicas }}
+  {{- with .Values.proxy.replicas }}
+  replicas: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       app: traefikee

--- a/traefikee/tests/proxy_test.yaml
+++ b/traefikee/tests/proxy_test.yaml
@@ -200,7 +200,22 @@ tests:
           path: spec.template.spec.tolerations
           content:
             key: "RSA"
-            operator: "Destructor"            
+            operator: "Destructor"
+  - it: should not have replicas when set to
+    set:
+      proxy:
+        replicas: 0
+    asserts:
+      - notExists:
+          path: spec.replicas
+  - it: should not have replicas when set to null
+    set:
+      proxy:
+        replicas: null
+    asserts:
+      - notExists:
+          path: spec.replicas
+
 ---
 suite: proxy service test
 templates:
@@ -227,6 +242,22 @@ tests:
       - equal:
           path: spec.type
           value: NodePort
+  - it: should set loadbalancerIP
+    set:
+      proxy:
+        loadBalancerIP: "1.2.3.4"
+        serviceType: loadBalancer
+    asserts:
+      - isKind:
+          of: Service
+      - isAPIVersion:
+          of: v1
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.loadBalancerIP
+          value: "1.2.3.4"
   - it: should set loadbalancerIP
     set:
       proxy:

--- a/traefikee/values.yaml
+++ b/traefikee/values.yaml
@@ -124,6 +124,8 @@ controller:
   tolerations: []
 
 proxy:
+  # Can be set to null when using HPA, in order to avoid conflict between HPA
+  # and this Chart on replicas.
   replicas: 2
   resources:
     requests:


### PR DESCRIPTION
# Motivation

When using HPA on proxy, the Chart should not handle the replicas field. 
See [kubernetes doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#autoscaling-during-rolling-update) for more details.