### PR TITLE
Add support for topology spread constraints on the controller

### DIFF
--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: traefikee
-version: 1.15.0
+version: 1.15.1
 # renovate: image=docker.io/traefik/traefikee
 appVersion: v2.10.4
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.

--- a/traefikee/templates/stateful-sets.yaml
+++ b/traefikee/templates/stateful-sets.yaml
@@ -198,6 +198,13 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.controller.topologySpreadConstraints }}
+      {{- if (semverCompare "<1.19.0-0" .Capabilities.KubeVersion.Version) }}
+        {{- fail "ERROR: topologySpreadConstraints are supported only on kubernetes >= v1.19" -}}
+      {{- end }}
+      topologySpreadConstraints:
+        {{- tpl (toYaml .Values.controller.topologySpreadConstraints) . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/traefikee/tests/controller_test.yaml
+++ b/traefikee/tests/controller_test.yaml
@@ -335,6 +335,34 @@ tests:
               cpu: "300m"
               memory: "150Mi"
         documentIndex: 2
+  - it: should not set topologySpreadConstraints by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.topologySpreadConstraints
+  - it: should set topologySpreadConstraints
+    set:
+      controller:
+        topologySpreadConstraints:
+          - labelSelector:
+              matchLabels:
+                app: traefikee
+                component: controllers
+            maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: DoNotSchedule
+    asserts:
+      - isSubset:
+          path: spec.template.spec
+          content:
+            topologySpreadConstraints:
+              - labelSelector:
+                  matchLabels:
+                    app: traefikee
+                    component: controllers
+                maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: DoNotSchedule
+    documentIndex: 2
   - it: should not set tolerations by default
     asserts:
       - isNull:

--- a/traefikee/values.yaml
+++ b/traefikee/values.yaml
@@ -120,6 +120,16 @@ controller:
 #        secretKeyRef:
 #          name: foo
 #          key: BAR
+# # This example topologySpreadConstraints forces the scheduler to put traefikee controller pods
+# # on nodes where no other traefikee controller pods are scheduled.
+#  topologySpreadConstraints:
+#    - labelSelector:
+#        matchLabels:
+#          app: traefikee
+#          component: controllers
+#      maxSkew: 1
+#      topologyKey: kubernetes.io/hostname
+#      whenUnsatisfiable: DoNotSchedule
 ## Tolerations allow the scheduler to schedule pods with matching taints.
   tolerations: []
 


### PR DESCRIPTION
### What does this PR do?

* adds topology spread constraints for controllers, mirroring proxy config added in #69 

### Motivation

https://traefik.zendesk.com/hc/en-us/requests/4174 and 4181

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed


