### PR TITLE
feat: add readiness and liveness on all pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ repo/
 __snapshot__
 .idea
 
+# vim temporary files
+*.swp
+*.swo
+
 # Chart dependencies
 **/charts/*.tgz
 Chart.lock

--- a/traefikee/templates/proxy/deployment.yaml
+++ b/traefikee/templates/proxy/deployment.yaml
@@ -135,15 +135,25 @@ spec:
           ports:
             - containerPort: 8484
               name: distributed
+            - containerPort: 8080
+              name: traefik
           {{- range $port := .Values.proxy.ports }}
             - containerPort: {{ $port.targetPort | default $port.port }}
               name: {{ $port.name }}
           {{- end }}
-          {{- if .Values.proxy.readinessProbe }}
+          {{- with .Values.proxy.readinessProbe }}
           readinessProbe:
-            {{- with .Values.proxy.readinessProbe }}
+            httpGet:
+              path: /ping
+              port: traefik
             {{- toYaml . | nindent 12 }}
-            {{- end }}
+          {{- end }}
+          {{- with .Values.proxy.livenessProbe }}
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: traefik
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.proxy.resources }}
           resources:

--- a/traefikee/templates/stateful-sets.yaml
+++ b/traefikee/templates/stateful-sets.yaml
@@ -68,7 +68,7 @@ spec:
       {{- if .Values.registry.tolerations }}
       tolerations:
         {{- tpl (toYaml .Values.registry.tolerations) . | nindent 8 }}
-      {{- end }}      
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
@@ -151,6 +151,16 @@ spec:
               name: http
             - containerPort: 443
               name: https
+          livenessProbe:
+            tcpSocket:
+              port: https
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: https
+            initialDelaySeconds: 2
+            periodSeconds: 5
           {{- with .Values.controller.resources }}
           resources:
             requests:
@@ -253,7 +263,7 @@ spec:
       {{- if .Values.controller.tolerations }}
       tolerations:
         {{- tpl (toYaml .Values.controller.tolerations) . | nindent 8 }}
-      {{- end }}   
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
@@ -349,6 +359,10 @@ spec:
               port: control-port
             initialDelaySeconds: 10
             periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: control-port
+            initialDelaySeconds: 10
           {{- with .Values.controller.resources }}
           resources:
             requests:
@@ -386,6 +400,7 @@ spec:
             - "--log.format={{ (.Values.log).format | default "" }}"
             - "--plugin.url=https://{{ .Values.cluster }}-plugin-registry-svc.{{ .Release.Namespace }}.svc.cluster.local"
             - "--plugin.token=$(PLUGIN_REGISTRY_TOKEN)"
+            - "--ping.entryPoint=traefik"
             {{- with .Values.controller.additionalArguments }}
             {{- range . }}
             - {{ . | quote }}

--- a/traefikee/tests/controller_test.yaml
+++ b/traefikee/tests/controller_test.yaml
@@ -103,6 +103,38 @@ tests:
                           values:
                             - controllers
                     topologyKey: kubernetes.io/hostname
+      - documentIndex: 1
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            tcpSocket:
+              port: https
+            initialDelaySeconds: 2
+            periodSeconds: 5
+      - documentIndex: 1
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            tcpSocket:
+              port: https
+            initialDelaySeconds: 2
+            periodSeconds: 5
+      - documentIndex: 2
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            tcpSocket:
+              port: control-port
+            initialDelaySeconds: 10
+            periodSeconds: 5
+      - documentIndex: 2
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            tcpSocket:
+              port: control-port
+            initialDelaySeconds: 10
+
   - it: should override controller defaults
     set:
       cluster: "mysupertraefikee"

--- a/traefikee/tests/proxy_test.yaml
+++ b/traefikee/tests/proxy_test.yaml
@@ -36,6 +36,22 @@ tests:
                             values:
                               - proxies
                       topologyKey: "kubernetes.io/hostname"
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: /ping
+              port: traefik
+            initialDelaySeconds: 2
+            periodSeconds: 5
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            httpGet:
+              path: /ping
+              port: traefik
+            initialDelaySeconds: 2
+            periodSeconds: 5
   - it: should override defaults
     set:
       cluster: "mysupertraefikee"
@@ -45,6 +61,12 @@ tests:
       proxy:
         replicas: 2
         affinity: null
+        readinessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          initialDelaySeconds: 10
+          periodSeconds: 20
     asserts:
       - isKind:
           of: Deployment
@@ -66,6 +88,23 @@ tests:
           count: 1
       - isNull:
           path: spec.template.spec.affinity
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            httpGet:
+              path: /ping
+              port: traefik
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            httpGet:
+              path: /ping
+              port: traefik
+            initialDelaySeconds: 10
+            periodSeconds: 20
+
   - it: should provide secure deployment by default
     asserts:
       - equal:

--- a/traefikee/values.yaml
+++ b/traefikee/values.yaml
@@ -200,11 +200,12 @@ proxy:
     #     - type: Pods
     #       value: 1
     #       periodSeconds: 60
-#  readinessProbe:
-#    tcpSocket:
-#      port: http
-#    initialDelaySeconds: 2
-#    periodSeconds: 5
+  readinessProbe:
+    initialDelaySeconds: 2
+    periodSeconds: 5
+  livenessProbe:
+    initialDelaySeconds: 2
+    periodSeconds: 5
 #  serviceLabels:
 #    foo: bar
 #  serviceAnnotations:


### PR DESCRIPTION
### What does this PR do?

1. Add readiness and liveness on `registry` using https port
2. Add liveness on `controller` using ¢ontrol-port
3. On proxy 
   * Enable by default readiness
   * Add a default liveness
   * Enable ping on `traefik` entrypoint and use it for readiness & liveness

### Motivation

More robust deployment. Part of #86.


### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

