### PR TITLE
fix: don't set plugin registry CLI when it's disabled

### DIFF
--- a/traefikee/templates/stateful-sets.yaml
+++ b/traefikee/templates/stateful-sets.yaml
@@ -400,8 +400,10 @@ spec:
             - "--log.level={{ (.Values.log).level | default "" }}"
             - "--log.filepath={{ (.Values.log).filepath | default "" }}"
             - "--log.format={{ (.Values.log).format | default "" }}"
+            {{- if .Values.registry.enabled }}
             - "--plugin.url=https://{{ .Values.cluster }}-plugin-registry-svc.{{ .Release.Namespace }}.svc.cluster.local"
             - "--plugin.token=$(PLUGIN_REGISTRY_TOKEN)"
+            {{- end }}
             {{- with .Values.controller.additionalArguments }}
             {{- range . }}
             - {{ . | quote }}

--- a/traefikee/tests/controller_test.yaml
+++ b/traefikee/tests/controller_test.yaml
@@ -280,6 +280,14 @@ tests:
           path: metadata.name
           value: default-controller
         documentIndex: 1
+      - notContains:
+          path: spec.template.spec.containers[0].command
+          content: "--plugin.url=https://default-plugin-registry-svc.NAMESPACE.svc.cluster.local"
+        documentIndex: 1
+      - notContains:
+          path: spec.template.spec.containers[0].command
+          content: "--plugin.token=$(PLUGIN_REGISTRY_TOKEN)"
+        documentIndex: 1
       - hasDocuments:
           count: 2
 


### PR DESCRIPTION
### What does this PR do?

Remove unneeded CLI command on controller when registry is disabled.

### Motivation

Remove _really_ registry when it's disabled. 

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

