### PR TITLE
Feat/configmap superseeds inline

### DIFF
--- a/traefikee/templates/NOTES.txt
+++ b/traefikee/templates/NOTES.txt
@@ -21,3 +21,11 @@ To learn more about the release, try:
 !!          This field may be removed in a future API version.                                                 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 {{ end }}
+
+{{- if and .Values.controller.staticConfig.configMap .Values.controller.staticConfig.content }}
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!! WARNING: you declared both .spec.controller.staticConfig.configMap and .spec.controller.staticConfig        !!
+!!          .content.                                                                                          !!
+!!          Only .spec.controller.staticConfig.configMap will be taken into account.                           !!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+{{ end }}

--- a/traefikee/templates/NOTES.txt
+++ b/traefikee/templates/NOTES.txt
@@ -21,25 +21,3 @@ To learn more about the release, try:
 !!          This field may be removed in a future API version.                                                 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 {{ end }}
-{{- with .Values.controller.staticConfig.configMap }}
-  {{- if and .name .key }}
-    {{- $data := (lookup "v1" "ConfigMap" $.Release.Namespace .name).data }}
-    {{- if hasKey $data .key }}
-      {{- $staticConfig := get $data .key }}
-      {{- if not (contains "ping" $staticConfig) }}
-        {{- if ($.Values.proxy.readinessProbe).httpGet }}
-          {{- if eq $.Values.proxy.readinessProbe.httpGet.path "/ping" }}
-            {{- fail "ERROR: Readiness Probe is configured using ping and ping is not enabled in staticConfig" }}
-          {{- end }}
-        {{- end }}
-        {{- if ($.Values.proxy.livenessProbe).httpGet }}
-          {{- if eq $.Values.proxy.livenessProbe.httpGet.path "/ping" }}
-            {{- fail "ERROR: Liveness Probe is configured using ping and ping is not enabled in staticConfig" }}
-          {{- end }}
-        {{- end }}
-      {{- end }}
-    {{- else }}
-      {{- fail (cat "ERROR: ConfigMap" .name "with" .key "key cannot be found in" $.Release.Namespace "namespace") }}
-    {{- end }}
-  {{- end }}
-{{- end }}

--- a/traefikee/templates/controller/config.yaml
+++ b/traefikee/templates/controller/config.yaml
@@ -1,7 +1,19 @@
-{{- if .Values.controller.staticConfig.content }}
+{{ $staticConfig := ""}}
 {{- if .Values.controller.staticConfig.configMap }}
-{{- fail "ERROR: Can not set both content and configMap on staticConfig" }}
-{{- end }}
+  {{- with .Values.controller.staticConfig.configMap }}
+    {{- if and .name .key }}
+      {{- $data := (lookup "v1" "ConfigMap" $.Release.Namespace .name).data }}
+      {{- if hasKey $data .key }}
+        {{- $staticConfig = get $data .key }}
+      {{- else }}
+        {{- fail (cat "ERROR: ConfigMap" .name "with" .key "key cannot be found in" $.Release.Namespace "namespace") }}
+      {{- end }}
+    {{- else }}
+      {{- fail (cat "ERROR: You need to specify both name and key while using configMap for staticConfig") }}
+    {{- end }}
+  {{- end }}
+{{ else }}
+{{ $staticConfig = tpl (toYaml .Values.controller.staticConfig.content) . }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -11,5 +23,18 @@ metadata:
   labels: {{ include "common.labels" . | nindent 4 }}
 data:
   static.yaml:
-    {{- tpl (toYaml .Values.controller.staticConfig.content) . | nindent 4 }}
+    {{- $staticConfig | nindent 4 }}
+{{- end }}
+
+{{- if not (contains "ping" $staticConfig) }}
+  {{- if ($.Values.proxy.readinessProbe).httpGet }}
+    {{- if eq $.Values.proxy.readinessProbe.httpGet.path "/ping" }}
+      {{- fail "ERROR: Readiness Probe is configured using ping and ping is not enabled in staticConfig" }}
+    {{- end }}
+  {{- end }}
+  {{- if ($.Values.proxy.livenessProbe).httpGet }}
+    {{- if eq $.Values.proxy.livenessProbe.httpGet.path "/ping" }}
+      {{- fail "ERROR: Liveness Probe is configured using ping and ping is not enabled in staticConfig" }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/traefikee/tests/controller_config_test.yaml
+++ b/traefikee/tests/controller_config_test.yaml
@@ -1,0 +1,23 @@
+suite: controller config test
+templates:
+  - controller/config.yaml
+tests:
+  - it: should provide default static config
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - isAPIVersion:
+          of: v1
+      - equal:
+          path: metadata.name
+          value: default-static-config
+  - it: should fail because of conflicting config
+    set:
+      controller:
+        staticConfig:
+          configMap:
+            name: traefik-config
+            key: "static.yml"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: Can not set both content and configMap on staticConfig"

--- a/traefikee/tests/controller_config_test.yaml
+++ b/traefikee/tests/controller_config_test.yaml
@@ -11,7 +11,7 @@ tests:
       - equal:
           path: metadata.name
           value: default-static-config
-  - it: should fail because of conflicting config
+  - it: configmap should supersede contents
     set:
       controller:
         staticConfig:
@@ -20,4 +20,48 @@ tests:
             key: "static.yml"
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: Can not set both content and configMap on staticConfig"
+          errorMessage: "ERROR: ConfigMap traefik-config with static.yml key cannot be found in NAMESPACE namespace"
+  - it: configmap should fail when not fully specified
+    set:
+      controller:
+        staticConfig:
+          configMap:
+            key: "static.yml"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: You need to specify both name and key while using configMap for staticConfig"
+  - it: config should fail when ping not enabled for readiness
+    set:
+      controller:
+        staticConfig:
+          content: test
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: Readiness Probe is configured using ping and ping is not enabled in staticConfig"
+  - it: config should fail when ping not enabled for liveness
+    set:
+      controller:
+        staticConfig:
+          content: test
+      proxy:
+        readinessProbe:
+         httpGet:
+          path: "/pong"
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: Liveness Probe is configured using ping and ping is not enabled in staticConfig"
+  - it: config should not fail when ping is not needed
+    set:
+      controller:
+        staticConfig:
+          content: test
+      proxy:
+        livenessProbe:
+          httpGet:
+            path: "/pong"
+        readinessProbe:
+          httpGet:
+            path: "/pong"
+    asserts:
+      - hasDocuments:
+          count: 1


### PR DESCRIPTION
### What does this PR do?

This PR resolves conflicting configuration by giving priority to a staticConfig using configMap if provided.


### Motivation

Relates https://github.com/traefik/traefikee-helm-chart/issues/101.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

