### PR TITLE
fix: :see_no_evil: allow user to run proxy on priviledged ports

### DIFF
--- a/traefikee/templates/proxy/deployment.yaml
+++ b/traefikee/templates/proxy/deployment.yaml
@@ -123,7 +123,8 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
-            runAsUser: 65532
+            runAsNonRoot: {{ if eq (int .Values.proxy.securityContext.runAsUser) 0 -}}false{{- else -}}true{{- end }}
+            runAsUser: {{ .Values.proxy.securityContext.runAsUser }}
             readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
@@ -137,7 +138,7 @@ spec:
               name: distributed
           {{- range $port := .Values.proxy.ports }}
             {{- $containerPort := ($port.targetPort | default $port.port) }}
-            {{- if lt (int $containerPort) 1024 }}
+            {{- if and (lt (int $containerPort) 1024) (ne (int $.Values.proxy.securityContext.runAsUser) 0) }}
               {{ fail "ERROR: Cannot set a privileged port on a non-root container" }}
             {{- end }}
             - containerPort: {{ $containerPort }}

--- a/traefikee/tests/proxy_test.yaml
+++ b/traefikee/tests/proxy_test.yaml
@@ -273,7 +273,7 @@ tests:
               rollingUpdate:
                 maxUnavailable: 0
                 maxSurge: 1
-  - it: should fail when using ports < 1024
+  - it: should fail when using ports < 1024 for non-root users
     set:
       proxy:
         ports:
@@ -282,6 +282,20 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "ERROR: Cannot set a privileged port on a non-root container"
+  - it: should be possible to run proxies as root (to specify elevated ports)
+    set:
+      proxy:
+        ports:
+          - name: http
+            port: 80
+        securityContext:
+          runAsUser: 0
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 80
+            name: http
   - it: should be possible to change ports of deployments
     set:
       proxy:

--- a/traefikee/values.yaml
+++ b/traefikee/values.yaml
@@ -111,7 +111,7 @@ controller:
         traefik:
           address: ":9000"
         web:
-          address: ":7000"
+          address: ":7080"
         websecure:
           http:
             tls: {}
@@ -248,6 +248,8 @@ proxy:
       port: traefik
     initialDelaySeconds: 2
     periodSeconds: 5
+  securityContext:
+    runAsUser: 65532
 
 #  serviceLabels:
 #    foo: bar


### PR DESCRIPTION
### What does this PR do?

This allow users to run traefik proxy on port < 1024.


### Motivation

Release 2.0.0 was breaking on this aspect and we don't we to block those users.


### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

