### PR TITLE
add Ingressclass

### DIFF
--- a/traefikee/templates/_helpers.tpl
+++ b/traefikee/templates/_helpers.tpl
@@ -103,3 +103,10 @@ Generates or load registry token.
   {{- end }}
 {{- printf "%s" $tokenStr | nospace | b64enc }}
 {{- end }}
+
+{{/*
+Set imageVersion from Chart
+*/}}
+{{- define "imageVersion" -}}
+{{ (split "@" (default $.Chart.AppVersion $.Values.image.tag))._0 }}
+{{- end -}}

--- a/traefikee/templates/ingressclass.yaml
+++ b/traefikee/templates/ingressclass.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.ingressClass.enabled -}}
+  {{- if (semverCompare "<2.3.0" (include "imageVersion" $)) -}}
+    {{- fail "ERROR: IngressClass cannot be used with Traefik Enterprise < 2.3.0" -}}
+  {{- end -}}
+  {{- if semverCompare ">=1.19.0-0" .Capabilities.KubeVersion.Version  -}}
+apiVersion: networking.k8s.io/v1
+  {{- else if semverCompare ">=1.16.0-0" .Capabilities.KubeVersion.Version }}
+apiVersion: networking.k8s.io/v1beta1
+  {{- else }}
+    {{- fail "ERROR: You must use at least Kubernetes v1.16 with this Chart" }}
+  {{- end }}
+kind: IngressClass
+metadata:
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: {{ .Values.ingressClass.isDefaultClass | quote }}
+  labels:
+    {{- include "traefik.labels" . | nindent 4 }}
+  name: {{ .Values.ingressClass.name | default (include "traefik.fullname" .) }}
+spec:
+  controller: traefik.io/ingress-controller
+{{- end -}}

--- a/traefikee/templates/ingressclass.yaml
+++ b/traefikee/templates/ingressclass.yaml
@@ -14,8 +14,8 @@ metadata:
   annotations:
     ingressclass.kubernetes.io/is-default-class: {{ .Values.ingressClass.isDefaultClass | quote }}
   labels:
-    {{- include "traefik.labels" . | nindent 4 }}
-  name: {{ .Values.ingressClass.name | default (include "traefik.fullname" .) }}
+    {{- include "common.labels" . | nindent 4 }}
+  name: {{ .Values.ingressClass.name | default (include "traefikee-helm-chart.fullname" .) }}
 spec:
   controller: traefik.io/ingress-controller
 {{- end -}}

--- a/traefikee/tests/ingressclass-config_test.yaml
+++ b/traefikee/tests/ingressclass-config_test.yaml
@@ -1,0 +1,82 @@
+suite: IngressClass configuration
+templates:
+  - ingressclass.yaml
+tests:
+  - it: should not provide an IngressClass when disabled
+    set:
+      ingressClass:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should provide a default IngressClass by default and prefer v1 api
+    asserts:
+      - isKind:
+          of: IngressClass
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations["ingressclass.kubernetes.io/is-default-class"]
+          value: "true"
+  - it: should be possible to provide a non-default IngressClass
+    set:
+      ingressClass:
+        isDefaultClass: false
+    asserts:
+      - isKind:
+          of: IngressClass
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.annotations["ingressclass.kubernetes.io/is-default-class"]
+          value: "false"
+  - it: should provide an IngressClass with only v1beta1 api on Kubernetes v1.18
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    asserts:
+      - isKind:
+          of: IngressClass
+      - isAPIVersion:
+          of: networking.k8s.io/v1beta1
+  - it: should workaround and provide an IngressClass with v1 with only Capability (#698)
+    capabilities:
+      majorVersion: 1
+      minorVersion: 21
+      patchVersion: 14-eks-6d3986b
+    asserts:
+      - isKind:
+          of: IngressClass
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+  - it: should fail when asking to deploy IngressClass on Traefik < 2.3
+    set:
+      ingressClass:
+        enabled: true
+    chart:
+      appVersion: v2.1.0
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: IngressClass cannot be used with Traefik < 2.3.0"
+  - it: should fail when asking to deploy IngressClass on Kubernetes < v1.16
+    capabilities:
+      majorVersion: 1
+      minorVersion: 15
+    asserts:
+      - failedTemplate:
+          errorMessage: "ERROR: You must use at least Kubernetes v1.16 with this Chart"
+  - it: should be possible to provide an IngressClass name
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      ingressClass:
+        name: nondefaultname
+    asserts:
+      - isKind:
+          of: IngressClass
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: nondefaultname

--- a/traefikee/tests/ingressclass-config_test.yaml
+++ b/traefikee/tests/ingressclass-config_test.yaml
@@ -10,6 +10,10 @@ tests:
       - hasDocuments:
           count: 0
   - it: should provide a default IngressClass by default and prefer v1 api
+    set:
+      ingressClass:
+        enabled: true
+        isDefaultClass: true
     asserts:
       - isKind:
           of: IngressClass
@@ -21,6 +25,7 @@ tests:
   - it: should be possible to provide a non-default IngressClass
     set:
       ingressClass:
+        enabled: true
         isDefaultClass: false
     asserts:
       - isKind:
@@ -34,6 +39,10 @@ tests:
     capabilities:
       majorVersion: 1
       minorVersion: 18
+    set:
+      ingressClass:
+        enabled: true
+        isDefaultClass: true
     asserts:
       - isKind:
           of: IngressClass
@@ -44,12 +53,16 @@ tests:
       majorVersion: 1
       minorVersion: 21
       patchVersion: 14-eks-6d3986b
+    set:
+      ingressClass:
+        enabled: true
+        isDefaultClass: true
     asserts:
       - isKind:
           of: IngressClass
       - isAPIVersion:
           of: networking.k8s.io/v1
-  - it: should fail when asking to deploy IngressClass on Traefik < 2.3
+  - it: should fail when asking to deploy IngressClass on Traefik Enterprise < 2.3
     set:
       ingressClass:
         enabled: true
@@ -57,8 +70,11 @@ tests:
       appVersion: v2.1.0
     asserts:
       - failedTemplate:
-          errorMessage: "ERROR: IngressClass cannot be used with Traefik < 2.3.0"
+          errorMessage: "ERROR: IngressClass cannot be used with Traefik Enterprise < 2.3.0"
   - it: should fail when asking to deploy IngressClass on Kubernetes < v1.16
+    set:
+      ingressClass:
+        enabled: true
     capabilities:
       majorVersion: 1
       minorVersion: 15
@@ -71,6 +87,8 @@ tests:
       minorVersion: 19
     set:
       ingressClass:
+        enabled: true
+        isDefaultClass: true
         name: nondefaultname
     asserts:
       - isKind:

--- a/traefikee/values.yaml
+++ b/traefikee/values.yaml
@@ -17,6 +17,12 @@ initImage:
   repository: busybox
   tag: "1.36.1"
 
+# -- Create a default IngressClass for Traefik
+ingressClass:
+  enabled: false
+  isDefaultClass: false
+  # name: my-custom-class
+
 # log:
 #  level: DEBUG
 #  format:
@@ -120,8 +126,10 @@ controller:
       providers:
         kubernetesIngress:
           allowEmptyServices: true
+          #ingressClass: foo
         kubernetesCRD:
           allowEmptyServices: true
+          #ingressClass: foo
 
 #  serviceLabels:
 #    foo: bar


### PR DESCRIPTION
### What does this PR do?

Adding ingressClass but not enabling it by default

To test the creation of the ingressClass with the deployment of Traefikee you can use this values:
```yaml
ingressClass:
  enabled: true
  isDefaultClass: true
  name: traefikee
```

### Motivation

Issue [#113](https://github.com/traefik/traefikee-helm-chart/issues/113)


### More

- [X] Yes, I updated the tests accordingly
- [X] Yes, I ran `make test` and all the tests passed

