### PR TITLE
[patch] controller service with cluster name label selector

### DIFF
--- a/traefikee/templates/controller/service.yaml
+++ b/traefikee/templates/controller/service.yaml
@@ -17,5 +17,6 @@ spec:
   selector:
     app: traefikee
     component: controllers
+    release: {{ .Values.cluster }}
   clusterIP: None
   publishNotReadyAddresses: true


### PR DESCRIPTION
### What does this PR do?

Patch controller service creation to add cluster name as label (already done for Registry service and Proxy service)


### Motivation

When deploying 2 separate deployments of Traefikee, the controller is messing up its configuration.


### More

- [X] Yes, I updated the tests accordingly
- [X] Yes, I ran `make test` and all the tests passed

