### PR TITLE
feat: custom proxy suffix

### DIFF
--- a/traefikee/templates/proxy/deployment.yaml
+++ b/traefikee/templates/proxy/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.cluster  }}-proxy
+  name: {{ .Values.cluster  }}-{{ .Values.proxy.suffix }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "common.labels" . | nindent 4 }}

--- a/traefikee/tests/proxy_test.yaml
+++ b/traefikee/tests/proxy_test.yaml
@@ -62,6 +62,7 @@ tests:
       image.tag: "myspecialversion"
       image.pullPolicy: Never
       proxy:
+        suffix: external-proxy
         replicas: 2
         affinity: null
         readinessProbe: null
@@ -73,7 +74,7 @@ tests:
           of: apps/v1
       - equal:
           path: metadata.name
-          value: mysupertraefikee-proxy
+          value: mysupertraefikee-external-proxy
       - equal:
           path: spec.template.spec.containers[0].image
           value: "my.registry/my/repository:myspecialversion"

--- a/traefikee/values.yaml
+++ b/traefikee/values.yaml
@@ -53,18 +53,12 @@ registry:
                   values:
                     - registry
             topologyKey: "kubernetes.io/hostname"
-#   serviceLabels:
-#     foo: bar
-#   serviceAnnotations:
-#     foo: bar
-#   statefulSetLabels:
-#     foo: bar
-#   statefulSetAnnotations:
-#     foo: bar
-#   podLabels:
-#     foo: bar
-#   podAnnotations:
-#     foo: bar
+  serviceLabels: {}
+  serviceAnnotations: {}
+  statefulSetLabels: {}
+  statefulSetAnnotations: {}
+  podLabels: {}
+  podAnnotations: {}
 ## Needed if you setup the registry token manually before deploying TraefikEE
 #  manualTokenSecret: true
 #  tokenSecretRef:
@@ -132,31 +126,18 @@ controller:
           allowEmptyServices: true
           ingressClass:
 
-#  serviceLabels:
-#    foo: bar
-#  serviceAnnotations:
-#    foo: bar
-#  statefulSetLabels:
-#    foo: bar
-#  statefulSetAnnotations:
-#    foo: bar
-#  podLabels:
-#    foo: bar
-#  podAnnotations:
-#    foo: bar
-#  additionalArguments:
+  serviceLabels: {}
+  serviceAnnotations: {}
+  statefulSetLabels: {}
+  statefulSetAnnotations: {}
+  podLabels: {}
+  podAnnotations: {}
+  additionalArguments:
 #    - --foo=bar
-#  env:
-#    - name: FOO
-#      value: 1
-#    - name: BAR
-#      valueFrom:
-#        secretKeyRef:
-#          name: foo
-#          key: BAR
+  env:
 # # This example topologySpreadConstraints forces the scheduler to put traefikee controller pods
 # # on nodes where no other traefikee controller pods are scheduled.
-#  topologySpreadConstraints:
+  topologySpreadConstraints:
 #    - labelSelector:
 #        matchLabels:
 #          app: traefikee
@@ -168,6 +149,8 @@ controller:
   tolerations: []
 
 proxy:
+  ## Proxy name is built with cluster name + this suffix.
+  suffix: proxy
   # Can be set to null when using HPA, in order to avoid conflict between HPA
   # and this Chart on replicas.
   replicas: 2


### PR DESCRIPTION
### What does this PR do?

It allows to customize proxy name, the part after cluster name.

### Motivation

It can be helpful to suffix both proxies when deploying two proxies at the same time.
Part of #118.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

