### PR TITLE
feat: 🚑️ disable chown on EFS volumes

### DIFF
--- a/traefikee/templates/stateful-sets.yaml
+++ b/traefikee/templates/stateful-sets.yaml
@@ -95,6 +95,7 @@ spec:
             capabilities:
               drop:
                 - NET_RAW
+        {{- if not .Values.disableChown }}
         - name: chown
           image: {{ template "traefikee-helm-chart.initContainer-image-name" . }}
           command: ['chown', '-R', '65532:', '/var/lib/traefikee', '/var/lib/plugins']
@@ -120,6 +121,7 @@ spec:
               mountPath: "/var/lib/traefikee"
             - name: plugin-data
               mountPath: "/var/lib/plugins"
+        {{- end }}
       containers:
         - name: {{ .Values.cluster }}-plugin-registry
           image: {{ template "traefikee-helm-chart.image-name" . }}
@@ -298,6 +300,7 @@ spec:
             capabilities:
               drop:
                 - NET_RAW
+        {{- if not .Values.disableChown }}
         - name: chown
           image: {{ template "traefikee-helm-chart.initContainer-image-name" . }}
           command: ['chown', '-R', '65532:', '/var/lib/traefikee']
@@ -321,6 +324,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/traefikee
+        {{- end }}
       containers:
         - name: {{ .Values.cluster }}-controller
           image: {{ template "traefikee-helm-chart.image-name" . }}

--- a/traefikee/tests/controller_test.yaml
+++ b/traefikee/tests/controller_test.yaml
@@ -556,3 +556,33 @@ tests:
           path: spec.volumeClaimTemplates[0].spec.storageClassName
           value: "test"
         documentIndex: 2
+  - it: should add chown init container by default
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+        documentIndex: 1
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+        documentIndex: 2
+  - it: should disable chown init container
+    set:
+      disableChown: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: "wait-dns"
+        documentIndex: 1
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 1
+        documentIndex: 1
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: "wait-dns"
+        documentIndex: 2
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 1
+        documentIndex: 2

--- a/traefikee/values.yaml
+++ b/traefikee/values.yaml
@@ -330,3 +330,6 @@ mesh:
 # but you can specify a custom one here
 volumeClaimTemplates:
   storageClassName:
+
+# set it to true if CSI driver don't allow it (e.g EFS)
+disableChown: false


### PR DESCRIPTION
### What does this PR do?

Allow people to disable the chown `initContainer`.

### Motivation

On EFS dynamic volume provisioning [doesn't allow chown](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/520).
When using `volumeClaimTemplates.storageClassName=efs-sc` where `efs-sc` uses `efs.csi.aws.com` provisioner the `chown` initContainer causes an init failure.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

