### PR TITLE
feat: dashboard ingressroute

### DIFF
--- a/traefikee/templates/dashboard-ingressroute.yaml
+++ b/traefikee/templates/dashboard-ingressroute.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingressRoute.dashboard.enabled -}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ .Values.cluster }}-dashboard
+  namespace: {{ $.Release.Namespace }}
+  annotations:
+    {{- with .Values.ingressRoute.dashboard.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+    {{- with .Values.ingressRoute.dashboard.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  entryPoints:
+  {{- range .Values.ingressRoute.dashboard.entryPoints }}
+  - {{ . }}
+  {{- end }}
+  routes:
+  - match: {{ .Values.ingressRoute.dashboard.matchRule }}
+    kind: Rule
+    services:
+    - name: api@internal
+      kind: TraefikService
+    {{- with .Values.ingressRoute.dashboard.middlewares }}
+    middlewares:
+      {{- toYaml . | nindent 6 }}
+    {{- end -}}
+
+  {{- with .Values.ingressRoute.dashboard.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/traefikee/tests/dashboard-ingressroute_test.yaml
+++ b/traefikee/tests/dashboard-ingressroute_test.yaml
@@ -1,0 +1,105 @@
+suite: Dashboard IngressRoute configuration
+templates:
+- dashboard-ingressroute.yaml
+tests:
+- it: should be disabled by default
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: should have the expected default route match rule
+  set:
+    ingressRoute:
+      dashboard:
+        enabled: true
+  asserts:
+  - equal:
+      path: spec.routes[0].match
+      value: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
+- it: should support overwriting the route match rule
+  set:
+    ingressRoute:
+      dashboard:
+        enabled: true
+        matchRule: Host(`traefik.example.com`)
+  asserts:
+  - equal:
+      path: spec.routes[0].match
+      value: Host(`traefik.example.com`)
+- it: should have traefik as default entryPoints
+  set:
+    ingressRoute:
+      dashboard:
+        enabled: true
+  asserts:
+  - equal:
+      path: spec.entryPoints
+      value: ["traefik"]
+- it: should support setting websecure as entryPoint
+  set:
+    ingressRoute:
+      dashboard:
+        enabled: true
+        entryPoints: ["websecure"]
+  asserts:
+  - equal:
+      path: spec.entryPoints
+      value: ["websecure"]
+- it: should support adding specific label on IngressRoute
+  set:
+    ingressRoute:
+      dashboard:
+        enabled: true
+        labels:
+          foo: bar
+  asserts:
+  - equal:
+      path: metadata.labels.foo
+      value: bar
+- it: should not have middlewares by default
+  set:
+    ingressRoute:
+      dashboard:
+        enabled: true
+  asserts:
+  - isNull:
+      path: spec.routes[0].middlewares
+- it: should support adding middlewares
+  set:
+    ingressRoute:
+      dashboard:
+        enabled: true
+        middlewares:
+        - name: traefik-dashboard-auth
+          namespace: default
+  asserts:
+  - equal:
+      path: spec.routes[0].middlewares
+      value:
+      - name: traefik-dashboard-auth
+        namespace: default
+- it: should not have tls options by default
+  set:
+    ingressRoute:
+      dashboard:
+        enabled: true
+  asserts:
+  - isNull:
+      path: spec.tls
+- it: should support adding tls options
+  set:
+    ingressRoute:
+      dashboard:
+        enabled: true
+        tls:
+          secretName: traefik-dashboard-auth
+          options:
+            name: tls-options
+            namespace: default
+  asserts:
+  - equal:
+      path: spec.tls
+      value:
+        secretName: traefik-dashboard-auth
+        options:
+          name: tls-options
+          namespace: default

--- a/traefikee/values.yaml
+++ b/traefikee/values.yaml
@@ -306,6 +306,26 @@ proxy:
 #      maxUnavailable: 0
 #      maxSurge: 1
 
+## Create an IngressRoute for the dashboard
+ingressRoute:
+  dashboard:
+    # -- Create an IngressRoute for the dashboard
+    enabled: false
+    # -- Additional ingressRoute annotations (e.g. for kubernetes.io/ingress.class)
+    annotations: {}
+    # -- Additional ingressRoute labels (e.g. for filtering IngressRoute by custom labels)
+    labels: {}
+    # -- The router match rule used for the dashboard ingressRoute
+    matchRule: PathPrefix(`/dashboard`) || PathPrefix(`/api`)
+    # -- Specify the allowed entrypoints to use for the dashboard ingress route, (e.g. traefik, web, websecure).
+    # By default, it's using traefik entrypoint, which is not exposed.
+    # /!\ Do not expose your dashboard without any protection over the internet /!\
+    entryPoints: ["traefik"]
+    # -- Additional ingressRoute middlewares (e.g. for authentication)
+    middlewares: []
+    # -- TLS options (e.g. secret containing certificate)
+    tls: {}
+
 # Optional additional proxy deployement
 # See values-dual-proxies.yaml for an example
 additionalProxies: {}


### PR DESCRIPTION
### What does this PR do?

Allows to create a dynamic configuration resource, `IngressRoute`, to display Traefik Enterprise dashboard.

### Motivation

See #130

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

