### PR TITLE
Fix - lower K8s version needed

### DIFF
--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -7,7 +7,7 @@ description: |
 icon: https://doc.traefik.io/traefik-enterprise/assets/images/logo-traefik-enterprise-logo.svg
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)
-kubeVersion: ">= 1.26.0-0"
+kubeVersion: ">= 1.23.0-0"
 version: 3.3.1
 # renovate: image=docker.io/traefik/traefikee
 appVersion: v2.10.9


### PR DESCRIPTION
### What does this PR do?

This PR reduce the minimum version of K8s needed to deploy Traefik Enterprise


### Motivation

AWS still support version 1.23 and 1.24 of K8s: [EKS Kubernetes versions](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)


### More

- [] Yes, I updated the tests accordingly
- [X] Yes, I ran `make test` and all the tests passed


No change is needed in the tests.

