### PR TITLE
chore(release): 🚀 publish v4.0.1

### DIFF
--- a/traefikee/Changelog.md
+++ b/traefikee/Changelog.md
@@ -1,8 +1,16 @@
 # Change Log
 
+## 4.0.1  ![AppVersion: v2.11.3](https://img.shields.io/static/v1?label=AppVersion&message=v2.11.3&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2024-07-11
+
+* chore(release): 🚀 publish v4.0.1
+* chore(deps): update docker.io/traefik/traefikee docker tag to v2.11.3
+
+
 ## 4.0.0  ![AppVersion: v2.11.2](https://img.shields.io/static/v1?label=AppVersion&message=v2.11.2&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-**Release date:** 2024-05-31
+**Release date:** 2024-06-03
 
 * fix: 🐛 apply disableChown also on proxy
 * feat(security)!: ✨ 🔒️ capabilities are droppped by default and can be set if needed

--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://doc.traefik.io/traefik-enterprise/assets/images/logo-traefik-enter
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)
 kubeVersion: ">= 1.23.0-0"
-version: 4.0.0
+version: 4.0.1
 # renovate: image=docker.io/traefik/traefikee
 appVersion: v2.11.3
 type: application
@@ -25,7 +25,5 @@ keywords:
   - traefik-enterprise
 annotations:
   artifacthub.io/changes: |
-    - "fix: 🐛 apply disableChown also on proxy"
-    - "feat(security)!: ✨ 🔒️ capabilities are droppped by default and can be set if needed"
-    - "chore(release): 🚀 publish v4.0.0"
-    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.11.2"
+    - "chore(release): 🚀 publish v4.0.1"
+    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.11.3"


### PR DESCRIPTION
### What does this PR do?

Release v4.0.1 to which includes traefikee v2.11.3 by default.


### Motivation

Fix Redis Sentinel support for OIDC and OAuth Token Introspection middlewares.

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

