### PR TITLE
chore(release): 🚀 publish v4.0.2

### DIFF
--- a/traefikee/Changelog.md
+++ b/traefikee/Changelog.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 4.0.2  ![AppVersion: v2.11.4](https://img.shields.io/static/v1?label=AppVersion&message=v2.11.4&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2024-08-08
+
+* chore(release): 🚀 publish v4.0.2
+* chore(deps): update docker.io/traefik/traefikee docker tag to v2.11.4
+
+
 ## 4.0.1  ![AppVersion: v2.11.3](https://img.shields.io/static/v1?label=AppVersion&message=v2.11.3&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2024-07-11

--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://doc.traefik.io/traefik-enterprise/assets/images/logo-traefik-enter
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)
 kubeVersion: ">= 1.23.0-0"
-version: 4.0.1
+version: 4.0.2
 # renovate: image=docker.io/traefik/traefikee
 appVersion: v2.11.4
 type: application
@@ -25,5 +25,5 @@ keywords:
   - traefik-enterprise
 annotations:
   artifacthub.io/changes: |
-    - "chore(release): 🚀 publish v4.0.1"
-    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.11.3"
+    - "chore(release): 🚀 publish v4.0.2"
+    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.11.4"


### PR DESCRIPTION
### What does this PR do?

Release v4.0.1 to which includes traefikee v2.11.4 by default.

### Motivation

Library updates and security fixes

