### PR TITLE
chore(release): 🚀 publish v4.0.6

### DIFF
--- a/traefikee/Changelog.md
+++ b/traefikee/Changelog.md
@@ -1,11 +1,19 @@
 # Change Log
 
+## 4.0.6  ![AppVersion: v2.11.8](https://img.shields.io/static/v1?label=AppVersion&message=v2.11.8&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2024-10-21
+
+* chore(release): 🚀 publish v4.0.6
+* chore(deps): update docker.io/traefik/traefikee docker tag to v2.11.8 (#163)
+
+
 ## 4.0.5  ![AppVersion: v2.11.7](https://img.shields.io/static/v1?label=AppVersion&message=v2.11.7&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2024-10-04
 
 * chore(release): 🚀 publish v4.0.5
-* chore(deps): update docker.io/traefik/traefikee docker tag to v2.11.7
+
 
 ## 4.0.4  ![AppVersion: v2.11.6](https://img.shields.io/static/v1?label=AppVersion&message=v2.11.6&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 

--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://doc.traefik.io/traefik-enterprise/assets/images/logo-traefik-enter
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)
 kubeVersion: ">= 1.23.0-0"
-version: 4.0.5
+version: 4.0.6
 # renovate: image=docker.io/traefik/traefikee
 appVersion: v2.11.8
 type: application
@@ -25,5 +25,5 @@ keywords:
   - traefik-enterprise
 annotations:
   artifacthub.io/changes: |
-    - "chore(release): 🚀 publish v4.0.5"
-    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.11.7"
+    - "chore(release): 🚀 publish v4.0.6"
+    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.11.8 (#163)"


### PR DESCRIPTION
### What does this PR do?

Release v4.0.6 to which includes Traefik Enterprise v2.11.8 by default.

### Motivation

Library updates and security fixes