### PR TITLE
chore(release): publish v4.2.0

### DIFF
--- a/traefikee/Changelog.md
+++ b/traefikee/Changelog.md
@@ -1,5 +1,41 @@
 # Change Log
 
+## 4.2.0  ![AppVersion: v2.12.1](https://img.shields.io/static/v1?label=AppVersion&message=v2.12.1&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2024-12-12
+
+* feat: :sparkles: make proxy wait for plugin registry
+* chore(release): publish v4.2.0
+* chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.1
+
+### Default value changes
+
+```diff
+diff --git a/traefikee/values.yaml b/traefikee/values.yaml
+index 12154b9..4d75cd3 100644
+--- a/traefikee/values.yaml
++++ b/traefikee/values.yaml
+@@ -219,7 +219,6 @@ proxy:
+   loadBalancerIP:
+   loadBalancerSourceRanges:
+ 
+-
+   # To disable affinity at all set this value to null
+   affinity:
+     nodeAffinity:
+@@ -268,6 +267,10 @@ proxy:
+     #       value: 1
+     #       periodSeconds: 60
+ 
++## Enable init container to wait for plugin registry to be ready
++  enablePluginWait: false
++
++
+ ## Those probes need for ping to be enabled in static config
+   readinessProbe:
+     httpGet:
+```
+
 ## 4.1.0  ![AppVersion: v2.12.0](https://img.shields.io/static/v1?label=AppVersion&message=v2.12.0&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2024-11-29

--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://doc.traefik.io/traefik-enterprise/assets/images/logo-traefik-enter
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)
 kubeVersion: ">= 1.23.0-0"
-version: 4.1.0
+version: 4.2.0
 # renovate: image=docker.io/traefik/traefikee
 appVersion: v2.12.1
 type: application
@@ -25,6 +25,6 @@ keywords:
   - traefik-enterprise
 annotations:
   artifacthub.io/changes: |
-    - "feat: ✨ update CRDs to v2.12.0"
-    - "chore(release): 🚀 publish v4.1.0"
-    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.0"
+    - "feat: :sparkles: make proxy wait for plugin registry"
+    - "chore(release): publish v4.2.0"
+    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.1"


### PR DESCRIPTION
### What does this PR do?

Release v4.2.0 to which includes Traefik Enterprise v2.12.1 by default.

### Motivation

New features, library updates and security fixes

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

