### PR TITLE
chore(release): publish v4.2.1

### DIFF
--- a/traefikee/Changelog.md
+++ b/traefikee/Changelog.md
@@ -1,8 +1,15 @@
 # Change Log
 
+## 4.2.1  ![AppVersion: v2.12.2](https://img.shields.io/static/v1?label=AppVersion&message=v2.12.2&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2025-02-13
+
+* chore(release): publish v4.2.1
+* chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.2
+
 ## 4.2.0  ![AppVersion: v2.12.1](https://img.shields.io/static/v1?label=AppVersion&message=v2.12.1&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
-**Release date:** 2024-12-12
+**Release date:** 2024-12-16
 
 * feat: :sparkles: make proxy wait for plugin registry
 * chore(release): publish v4.2.0

--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://doc.traefik.io/traefik-enterprise/assets/images/logo-traefik-enter
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)
 kubeVersion: ">= 1.23.0-0"
-version: 4.2.0
+version: 4.2.1
 # renovate: image=docker.io/traefik/traefikee
 appVersion: v2.12.2
 type: application
@@ -25,6 +25,5 @@ keywords:
   - traefik-enterprise
 annotations:
   artifacthub.io/changes: |
-    - "feat: :sparkles: make proxy wait for plugin registry"
-    - "chore(release): publish v4.2.0"
-    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.1"
+    - "chore(release): publish v4.2.1"
+    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.2"


### PR DESCRIPTION
### What does this PR do?

Release v4.2.1 to which includes Traefik Enterprise v2.12.2 by default.

### Motivation

New features, library updates and security fixes.

### More

- [ ] Yes, I updated the tests accordingly
- [X] Yes, I ran `make test` and all the tests passed
