### PR TITLE
chore(release): publish v4.2.2

### DIFF
--- a/traefikee/Changelog.md
+++ b/traefikee/Changelog.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 4.2.2  ![AppVersion: v2.12.3](https://img.shields.io/static/v1?label=AppVersion&message=v2.12.3&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2025-04-24
+
+* chore(release): publish v4.2.2
+* chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.3
+
 ## 4.2.1  ![AppVersion: v2.12.2](https://img.shields.io/static/v1?label=AppVersion&message=v2.12.2&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2025-02-13

--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -8,9 +8,9 @@ icon: https://doc.traefik.io/traefik-enterprise/assets/images/logo-traefik-enter
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)
 kubeVersion: ">= 1.23.0-0"
-version: 4.2.1
+version: 4.2.2
 # renovate: image=docker.io/traefik/traefikee
-appVersion: v2.12.2
+appVersion: v2.12.3
 type: application
 home: https://traefik.io/traefik-enterprise/
 maintainers:
@@ -25,5 +25,5 @@ keywords:
   - traefik-enterprise
 annotations:
   artifacthub.io/changes: |
-    - "chore(release): publish v4.2.1"
-    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.2"
+    - "chore(release): publish v4.2.2"
+    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.3"


### PR DESCRIPTION
### What does this PR do?

Release v4.2.2, which includes Traefik Enterprise v2.12.3 by default.

### Motivation

New features, library updates, and security fixes.

### More

- [ ] Yes, I updated the tests accordingly
- [X] Yes, I ran `make test` and all the tests passed
