### PR TITLE
chore(release): publish v4.2.10

### DIFF
--- a/traefikee/Changelog.md
+++ b/traefikee/Changelog.md
@@ -4,8 +4,8 @@
 
 **Release date:** 2026-08-26
 
+* chore(release): publish v4.2.10
 * chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.10
-* Prep v4.2.10
 
 
 ## 4.2.9  ![AppVersion: v2.12.9](https://img.shields.io/static/v1?label=AppVersion&message=v2.12.9&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)

--- a/traefikee/Changelog.md
+++ b/traefikee/Changelog.md
@@ -12,10 +12,10 @@
 
 **Release date:** 2026-07-20
 
+* chore(release): publish v4.2.9
 * chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.9
 * chore(deps): update docker.io/busybox docker tag to v1.38.0
 * Update CRDs to v0.19.0
-* Prep v4.2.9
 
 ### Default value changes
 

--- a/traefikee/Changelog.md
+++ b/traefikee/Changelog.md
@@ -1,13 +1,21 @@
 # Change Log
 
+## 4.2.10  ![AppVersion: v2.12.10](https://img.shields.io/static/v1?label=AppVersion&message=v2.12.10&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
+
+**Release date:** 2026-08-26
+
+* chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.10
+* Prep v4.2.10
+
+
 ## 4.2.9  ![AppVersion: v2.12.9](https://img.shields.io/static/v1?label=AppVersion&message=v2.12.9&color=success&logo=) ![Kubernetes: >= 1.23.0-0](https://img.shields.io/static/v1?label=Kubernetes&message=%3E%3D+1.23.0-0&color=informational&logo=kubernetes) ![Helm: v3](https://img.shields.io/static/v1?label=Helm&message=v3&color=informational&logo=helm)
 
 **Release date:** 2026-07-20
 
-* chore(release): publish v4.2.9
 * chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.9
 * chore(deps): update docker.io/busybox docker tag to v1.38.0
 * Update CRDs to v0.19.0
+* Prep v4.2.9
 
 ### Default value changes
 

--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -25,5 +25,5 @@ keywords:
   - traefik-enterprise
 annotations:
   artifacthub.io/changes: |
+    - "chore(release): publish v4.2.10"
     - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.10"
-    - "Prep v4.2.10"

--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -25,7 +25,5 @@ keywords:
   - traefik-enterprise
 annotations:
   artifacthub.io/changes: |
-    - "chore(release): publish v4.2.9"
-    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.9"
-    - "chore(deps): update docker.io/busybox docker tag to v1.38.0"
-    - "Update CRDs to v0.19.0"
+    - "chore(deps): update docker.io/traefik/traefikee docker tag to v2.12.10"
+    - "Prep v4.2.10"

--- a/traefikee/Chart.yaml
+++ b/traefikee/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://doc.traefik.io/traefik-enterprise/assets/images/logo-traefik-enter
 # Because of https://github.com/helm/helm/issues/3810 the pre-release version suffix has to be define.
 # This allows the installation on Kubernetes cluster with a pre-release version (e.g. v1.19.9-gke.1900)
 kubeVersion: ">= 1.23.0-0"
-version: 4.2.9
+version: 4.2.10
 # renovate: image=docker.io/traefik/traefikee
 appVersion: v2.12.10
 type: application


### PR DESCRIPTION
### What does this PR do?

Release v4.2.10, which includes Traefik Enterprise v2.12.10 by default.